### PR TITLE
Install as a development dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ During a commit check Drupal code for deprecations and discover bugs via static 
 
 Install it using composer:
 
-```composer require metadrop/grumphp-drupal-check```
+```composer require --dev metadrop/grumphp-drupal-check```
 
 
 # Usage


### PR DESCRIPTION
This repo is a fork of Esrohym/grumphp-drupal-check, but composer package is called metadrop/grumphp-drupal-check.

Which project is to be used?