### PR TITLE
Add support for drupal root directory argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ extensions:
 2) Add drupal check to the tasks:
 ```
 tasks:
-  drupalcheck: ~
+  drupalcheck:
+    drupal_root: ~
 ```
-
+Optionally, configure the path to the Drupal root. This fallback option can be used if drupal-check could not identify Drupal root from the provided path(s). This is useful when testing a module as opposed to a Drupal installation.

--- a/src/DrupalCheck.php
+++ b/src/DrupalCheck.php
@@ -31,7 +31,7 @@ class DrupalCheck extends AbstractExternalTask
    */
   public function canRunInContext(ContextInterface $context): bool
   {
-    return $context instanceof GitPreCommitContext || $context instanceof RunContext;
+      return $context instanceof GitPreCommitContext || $context instanceof RunContext;
   }
 
   /**

--- a/src/DrupalCheck.php
+++ b/src/DrupalCheck.php
@@ -43,7 +43,6 @@ class DrupalCheck extends AbstractExternalTask
       $resolver->setDefaults([
         'drupal_root' => null,
       ]);
-
       $resolver->addAllowedTypes('drupal_root', ['string']);
 
       return $resolver;

--- a/src/DrupalCheck.php
+++ b/src/DrupalCheck.php
@@ -73,6 +73,7 @@ class DrupalCheck extends AbstractExternalTask
     }
     $arguments = $this->processBuilder->createArgumentsForCommand('drupal-check');
     $arguments->add('--deprecations');
+    $arguments->add('--no-progress');
     $arguments->addOptionalArgument('--drupal-root=%s', $options['drupal_root']);
     $arguments->addFiles($files);
     $process = $this->processBuilder->buildProcess($arguments);

--- a/src/DrupalCheck.php
+++ b/src/DrupalCheck.php
@@ -39,14 +39,14 @@ class DrupalCheck extends AbstractExternalTask
    */
   public static function getConfigurableOptions(): OptionsResolver
   {
-    $resolver = new OptionsResolver();
-    $resolver->setDefaults([
-      'drupal_root' => null,
-    ]);
+      $resolver = new OptionsResolver();
+      $resolver->setDefaults([
+        'drupal_root' => null,
+      ]);
 
-    $resolver->addAllowedTypes('drupal_root', ['string']);
+      $resolver->addAllowedTypes('drupal_root', ['string']);
 
-    return $resolver;
+      return $resolver;
   }
 
   /**

--- a/src/DrupalCheck.php
+++ b/src/DrupalCheck.php
@@ -17,14 +17,6 @@ class DrupalCheck extends AbstractExternalTask
 {
 
   /**
-   * {@inheritdoc}
-   */
-  public function getName(): string
-  {
-    return 'drupalcheck';
-  }
-
-  /**
    * @param ContextInterface $context
    *
    * @return bool

--- a/src/DrupalCheck.php
+++ b/src/DrupalCheck.php
@@ -35,7 +35,7 @@ class DrupalCheck extends AbstractExternalTask
       $resolver->setDefaults([
         'drupal_root' => null,
       ]);
-      $resolver->addAllowedTypes('drupal_root', ['string']);
+      $resolver->addAllowedTypes('drupal_root', ['string', 'null']);
 
       return $resolver;
   }


### PR DESCRIPTION
--drupal-root Path to Drupal root. Fallback option if drupal-check could not identify Drupal root from the provided path(s).