### PR TITLE
Set minimal version 1.1.10 for drupal-check

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "type": "library",
     "require": {
         "phpro/grumphp": "~1.0",
-        "mglaman/drupal-check": "^1.1.2"
+        "mglaman/drupal-check": "^1.1.10"
     },
     "authors": [
         {


### PR DESCRIPTION
In order to avoid a bug, it is necessary to install version 1.1.10 https://github.com/mglaman/drupal-check/issues/233