### PR TITLE
Add analysis option to drupal-check

### DIFF
--- a/src/DrupalCheck.php
+++ b/src/DrupalCheck.php
@@ -63,6 +63,7 @@ class DrupalCheck extends AbstractExternalTask
         return TaskResult::createSkipped($this, $context);
     }
     $arguments = $this->processBuilder->createArgumentsForCommand('drupal-check');
+    $arguments->add('--analysis');
     $arguments->add('--deprecations');
     $arguments->add('--no-progress');
     $arguments->addOptionalArgument('--drupal-root=%s', $options['drupal_root']);


### PR DESCRIPTION
Add analysis option when running drupal-check to not only check for deprecation but other issues in code.