### PR TITLE
Allow for more recent versions of grumphp

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "Execute drupal check in a grumphp task.",
     "type": "library",
     "require": {
-        "phpro/grumphp": "~1.0",
+        "phpro/grumphp": "^1.0",
         "mglaman/drupal-check": "^1.1.10"
     },
     "authors": [


### PR DESCRIPTION
Currently `phpro/grumphp` installs as `v1.5.0` which isn't compatible with PHP 8.1. I see numerous warnings when using GrumPHP and PHP 8.1, including: 
```
Deprecated: strlen(): Passing null to parameter #1 ($string) of type string is deprecated in /var/www/html/vendor/symfony/filesystem/Filesystem.php on line 125
PHP Deprecated:  file_exists(): Passing null to parameter #1 ($filename) of type string is deprecated in /var/www/html/vendor/symfony/filesystem/Filesystem.php on line 129
```

Newer versions of the library should fix it.