### PR TITLE
Update for GrumPHP 2.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Description
 
-This repository adds a task for GrumPHP that launchs [drupal-check](https://github.com/mglaman/drupal-check).
+This repository adds a task for GrumPHP 2.x that launchs [drupal-check](https://github.com/mglaman/drupal-check).
 During a commit check Drupal code for deprecations and discover bugs via static analysis. If a deprecated code is detected, it won't pass.
 
 
@@ -24,15 +24,23 @@ extensions:
 tasks:
   drupalcheck:
     drupal_root: ~
-    memory_limit: ~
+    format: ~
     deprecations: true
     analysis: true
+    style: false
+    memory_limit: ~
+    exclude_dir: []
     php8: true
+    verbose: 0
 ```
 Optionally, you can define multiple DrupalCheck arguments:
 
 - **drupal_root** (string): Configure the path to the Drupal root. This fallback option can be used if drupal-check could not identify Drupal root from the provided path(s). This is useful when testing a module as opposed to a Drupal installation.
-- **memory_limit** (string): Configure memory limit for the process.
+- **format** (string): Format of output: raw, table, checkstyle, json, or junit. By default it is "table".
 - **deprecations** (boolean): Check code for deprecations. By default it is true.
 - **analysis** (boolean): Check code analysis.
+- **style** (boolean): Check code style.
+- **memory_limit** (string): Configure memory limit for the process.
+- **exclude_dir** (array): Directories to exclude.
 - **php8** (boolean): Set PHPStan phpVersion for 8.1 (Drupal 10 requirement).
+- **verbose** (int): Set verbose output (1 for normal verbose output, 2 for more verbose output and 3 for debug).

--- a/Services.yaml
+++ b/Services.yaml
@@ -1,0 +1,8 @@
+services:
+  GrumphpDrupalCheck\DrupalCheck:
+    class: GrumphpDrupalCheck\DrupalCheck
+    arguments:
+      - '@process_builder'
+      - '@formatter.raw_process'
+    tags:
+      - { name: grumphp.task, task: drupalcheck }

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "Execute drupal check in a grumphp task.",
     "type": "library",
     "require": {
-        "phpro/grumphp": "~1.0",
+        "phpro/grumphp": "^2.0.0",
         "mglaman/drupal-check": "^1.1.10"
     },
     "authors": [

--- a/src/DrupalCheck.php
+++ b/src/DrupalCheck.php
@@ -5,6 +5,7 @@ namespace GrumphpDrupalCheck;
 use GrumPHP\Runner\TaskResult;
 use GrumPHP\Runner\TaskResultInterface;
 use GrumPHP\Task\AbstractExternalTask;
+use GrumPHP\Task\Config\ConfigOptionsResolver;
 use GrumPHP\Task\Context\ContextInterface;
 use GrumPHP\Task\Context\GitPreCommitContext;
 use GrumPHP\Task\Context\RunContext;
@@ -21,6 +22,7 @@ class DrupalCheck extends AbstractExternalTask
    *
    * @return bool
    */
+  #[\Override]
   public function canRunInContext(ContextInterface $context): bool
   {
       return $context instanceof GitPreCommitContext || $context instanceof RunContext;
@@ -29,28 +31,39 @@ class DrupalCheck extends AbstractExternalTask
   /**
    * {@inheritdoc}
    */
-  public static function getConfigurableOptions(): OptionsResolver
+  #[\Override]
+  public static function getConfigurableOptions(): ConfigOptionsResolver
   {
       $resolver = new OptionsResolver();
       $resolver->setDefaults([
-        'drupal_root' => '',
-        'memory_limit' => '',
-        'deprecations' => true,
-        'analysis' => false,
-        'php8' => false,
+        'drupal_root' => '',    // Path to Drupal root.
+        'format' => 'table',    // Formatter to use: raw, table, checkstyle, json, or junit [default: "table"]
+        'deprecations' => TRUE, // Check for deprecations
+        'analysis' => TRUE,     // Check code analysis
+        'style' => FALSE,       // Check code style
+        'php8' => FALSE,        // Set PHPStan phpVersion for 8.1 (Drupal 10 requirement)
+        'memory_limit' => '',   // Memory limit for analysis
+        'exclude_dir' => [],    // Directories to exclude. Separate multiple directories with a comma, no spaces.
+        'verbose' => 0          // Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug
       ]);
-      $resolver->addAllowedTypes('drupal_root', ['string', 'null']);
-      $resolver->addAllowedTypes('memory_limit', ['string', 'null']);
-      $resolver->addAllowedTypes('deprecations', ['boolean']);
-      $resolver->addAllowedTypes('analysis', ['boolean']);
-      $resolver->addAllowedTypes('php8', ['boolean']);
 
-      return $resolver;
+      $resolver->addAllowedTypes('drupal_root', ['string']);
+      $resolver->addAllowedTypes('format', ['string']);
+      $resolver->addAllowedTypes('deprecations', ['bool']);
+      $resolver->addAllowedTypes('analysis', ['bool']);
+      $resolver->addAllowedTypes('style', ['bool']);
+      $resolver->addAllowedTypes('php8', ['bool']);
+      $resolver->addAllowedTypes('memory_limit', ['string']);
+      $resolver->addAllowedTypes('exclude_dir', ['array']);
+      $resolver->addAllowedTypes('verbose', ['int']);
+
+      return ConfigOptionsResolver::fromOptionsResolver($resolver);
   }
 
   /**
    * {@inheritdoc}
    */
+  #[\Override]
   public function run(ContextInterface $context): TaskResultInterface
   {
     $config = $this->getConfig();
@@ -67,16 +80,26 @@ class DrupalCheck extends AbstractExternalTask
       'theme',
     ];
     $files = $files->extensions($triggered_by);
-    if (0 === \count($files)) {
+    if (0 === count($files)) {
         return TaskResult::createSkipped($this, $context);
     }
-    $arguments = $this->processBuilder->createArgumentsForCommand('drupal-check');
-    !$options['analysis'] ?: $arguments->add('--analysis');
-    !$options['deprecations'] ?: $arguments->add('--deprecations');
-    !$options['php8'] ?: $arguments->add('--php8');
+    $arguments = $this->processBuilder->createArgumentsForCommand(('drupal-check'));
     $arguments->add('--no-progress');
     $arguments->addOptionalArgument('--drupal-root=%s', $options['drupal_root']);
+    $arguments->addOptionalArgument('--format=%s', $options['format']);
+    !$options['deprecations'] ?: $arguments->add('--deprecations');
+    !$options['analysis'] ?: $arguments->add('--analysis');
+    !$options['style'] ?: $arguments->add('--style');
+    !$options['php8'] ?: $arguments->add('--php8');
     $arguments->addOptionalArgument('--memory-limit=%s', $options['memory_limit']);
+    $arguments->addOptionalArgument('--exclude-dir=%s', implode(',', $options['exclude_dir']));
+    if ($options['verbose'] === 1) {
+        $arguments->add('-v');
+    } else if ($options['verbose'] === 2) {
+        $arguments->add('-vv');
+    } else if ($options['verbose'] === 3) {
+        $arguments->add('-vvv');
+    };
     $arguments->addFiles($files);
     $process = $this->processBuilder->buildProcess($arguments);
     $process->run();

--- a/src/ExtensionLoader.php
+++ b/src/ExtensionLoader.php
@@ -2,30 +2,16 @@
 namespace GrumphpDrupalCheck;
 
 use GrumPHP\Extension\ExtensionInterface;
-use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\DependencyInjection\Reference;
 
 /**
- * Load extensions for grumphp.
+ * Load extensions for GrumPHP (2.x).
  */
 class ExtensionLoader implements ExtensionInterface
 {
-    /**
-     * @param ContainerBuilder $container
-     *
-     * @return \Symfony\Component\DependencyInjection\Definition
-     * @throws \Exception
-     * @throws \Symfony\Component\DependencyInjection\Exception\BadMethodCallException
-     * @throws \Symfony\Component\DependencyInjection\Exception\InvalidArgumentException
-     * @throws \Symfony\Component\DependencyInjection\Exception\ServiceCircularReferenceException
-     * @throws \Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException
-     */
-    public function load(ContainerBuilder $container) : void
+    #[\Override]
+    public function imports(): iterable
     {
-        $container->register('task.drupalcheck', DrupalCheck::class)
-            ->addArgument(new Reference('process_builder'))
-            ->addArgument(new Reference('formatter.raw_process'))
-            ->addTag('grumphp.task', ['task' => 'drupalcheck']);
+        yield __DIR__ . '/../Services.yaml';
     }
 
 }


### PR DESCRIPTION
* src/DrupalCheck.php
Updated for GrumPHP 2.x and include additional options from drupal-check

* src/ExtensionLoader.php
Updated for GrumPHP 2.x

* composer.json
Update composer.json to require GrumPHP 2.x.

* README.md
Updated list of options for drupal-check.

* Services.yaml
Added as part of GrumPHP 2.x compatibility.